### PR TITLE
Parent div: fix bug scrollbar when game has 100% height

### DIFF
--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -41,6 +41,7 @@ class ReactUI extends Plugins.BasePlugin {
       cont.appendChild(this.game.canvas);
       cont.appendChild(reactcont);
       cont.style.position = 'relative'
+      cont.style.height = '100%'
       reactcont.style.position = 'absolute'
       reactcont.style.top = '0'
       reactcont.style.left = '0'


### PR DESCRIPTION
The parent div created by the plugincreate a unnitended scrollbar when the game as height set to 100%.

Setting the height to 100% for this parent div fix the issue.

@KingCosmic Just wondering if there are consequences for non 100% height games ?